### PR TITLE
Foce Intel i915/910 Graphics Drivers

### DIFF
--- a/install/scripts/1-install
+++ b/install/scripts/1-install
@@ -174,6 +174,7 @@ create_menulst()
 	create_entry "Android-x86 $VER (Debug mode)" $cmdline DEBUG=2
 	create_entry "Android-x86 $VER (Debug nomodeset)" nomodeset $cmdline DEBUG=2
 	create_entry "Android-x86 $VER (Debug video=LVDS-1:d)" video=LVDS-1:d $cmdline DEBUG=2
+	create_entry "Android-x86 $VER (Force Intel Graphics i915/i965)" i915.modeset=0 $cmdline
 }
 
 create_winitem()


### PR DESCRIPTION
May help the intel mobile i915/910GML graphics drivers for older 2004/2005 Laptops - https://downloadcenter.intel.com/product/81510/Graphics-Drivers-for-Mobile-Intel-915GM-GMS-910GML-Express-Chipset-Family