### PR TITLE
Android.mk: Remove unnecessary files for rpm build

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -85,6 +85,9 @@ $(boot_dir): $(shell find $(LOCAL_PATH)/boot -type f | sort -r) $(isolinux_files
 BUILT_IMG := $(addprefix $(PRODUCT_OUT)/,initrd.img install.img Androidx86-Installv28.5800.exe) $(systemimg)
 BUILT_IMG += $(if $(TARGET_PREBUILT_KERNEL),$(TARGET_PREBUILT_KERNEL),$(PRODUCT_OUT)/kernel)
 
+BUILT_RPM := $(addprefix $(PRODUCT_OUT)/,initrd.img ) $(systemimg)
+BUILT_RPM += $(if $(TARGET_PREBUILT_KERNEL),$(TARGET_PREBUILT_KERNEL),$(PRODUCT_OUT)/kernel)
+
 # Grab branch names
 KRNL := $(shell cd $(BUILD_TOP)/kernel ; git name-rev --name-only HEAD | cut -d '/' -f3)
 MSA := $(shell cd $(BUILD_TOP)/external/mesa ; git name-rev --name-only HEAD | cut -d '/' -f3)
@@ -167,7 +170,7 @@ $(ISO_IMAGE): $(boot_dir) $(BUILT_IMG)
 
 	@echo -e "\n\n$@ is built successfully.\n\n"
 
-rpm: $(wildcard $(LOCAL_PATH)/rpm/*) $(BUILT_IMG)
+rpm: $(wildcard $(LOCAL_PATH)/rpm/*) $(BUILT_RPM)
 	@echo ----- Making an rpm ------
 	OUT=$(abspath $(PRODUCT_OUT)); mkdir -p $$OUT/rpm/BUILD; rm -rf $$OUT/rpm/RPMS/*; $(ACP) $< $$OUT; \
 	echo $(VER) | grep -vq rc; EPOCH=$$((-$$? + `echo $(VER) | cut -d. -f1`)); \


### PR DESCRIPTION
Remove `install.img` and `Androidx86-Installv28.5800.exe` as it's not needed for rpm build. Build is still in progress so would be better if I can report whether the package succeeds to boot or not before merging.

Other suggestions are:

* Prettify the build success message when building with rpm so it looks similar to iso build. 
* Follow iso output naming scheme for rpm package naming so people can expect addons and which kernel is bundled inside it
* Use if-else instead of splitting `BUILT_IMG` and `BUILT_RPM`

I probably can attempt the change myself but I'm inexperienced with bash script and the team's coding style, so I keep my changes to as minimum and as simple as possible.