### PR TITLE
Update ffmpeg boot flags

### DIFF
--- a/boot/isolinux/isolinux.cfg
+++ b/boot/isolinux/isolinux.cfg
@@ -24,7 +24,7 @@ label live_intel
 label live_pc_intel
 	menu label PC-Mode (Intel) w/ FFMPEG
 	kernel /kernel
-	append initrd=/initrd.img CMDLINE quiet SRC= DATA= HWC=drm_minigbm_celadon GRALLOC=minigbm FFMPEG_CODEC=1 FFMPEG_PREFER_C2=1
+	append initrd=/initrd.img CMDLINE quiet SRC= DATA= HWC=drm_minigbm_celadon GRALLOC=minigbm FFMPEG_OMX_CODEC=1 FFMPEG_CODEC2_PREFER=1
 
 label install
 	menu label ^Installation - Install OS_TITLE to harddisk

--- a/install/grub2/efi/boot/android.cfg
+++ b/install/grub2/efi/boot/android.cfg
@@ -95,9 +95,9 @@ export android bootefi grub kdir live src
 
 # Create main menu
 add_entry "$live" quiet
-add_entry "$live (Default) w/ FFMPEG" quiet FFMPEG_CODEC=1 FFMPEG_PREFER_C2=1
+add_entry "$live (Default) w/ FFMPEG" quiet FFMPEG_OMX_CODEC=1 FFMPEG_CODEC2_PREFER=1
 add_entry "$live PC-Mode (Default)" quiet PC_MODE=1
-add_entry "$live PC-Mode (Default) w/ FFMPEG" quiet PC_MODE=1 FFMPEG_CODEC=1 FFMPEG_PREFER_C2=1
+add_entry "$live PC-Mode (Default) w/ FFMPEG" quiet PC_MODE=1 FFMPEG_OMX_CODEC=1 FFMPEG_CODEC2_PREFER=1
 #WINDOWS_ENTRY
 
 if [ -s ($android)$kdir/install.img ]; then

--- a/install/refind/android.cfg
+++ b/install/refind/android.cfg
@@ -5,7 +5,7 @@ menuentry "OS_TITLE VER" {
     initrd /android-VER/initrd.img
     options "CMDLINE SRC=/android-VER"
     submenuentry "boot with FFMPEG codecs" {
-        add_options "FFMPEG_CODEC=1 FFMPEG_PREFER_C2=1"
+        add_options "FFMPEG_OMX_CODEC=1 FFMPEG_CODEC2_PREFER=1"
     }
     submenuentry "boot with PC Mode" {
         add_options "PC_MODE=1"
@@ -14,7 +14,7 @@ menuentry "OS_TITLE VER" {
         add_options "HPE=1"
     }
     submenuentry "boot with PC Mode & FFMPEG codecs" {
-        add_options "PC_MODE=1 FFMPEG_CODEC=1 FFMPEG_PREFER_C2=1"
+        add_options "PC_MODE=1 FFMPEG_OMX_CODEC=1 FFMPEG_CODEC2_PREFER=1"
     }
     submenuentry "boot with DEBUG Mode" {
         add_options "DEBUG=2"


### PR DESCRIPTION
`FFMPEG_CODEC=1` and `FFMPEG_PREFER_C2=1` are not recognized anymore: https://github.com/BlissRoms-x86/device_generic_common/blob/cd6cfc232f663b2349a56b2f96d750d5645179cd/init.sh#L435